### PR TITLE
Arregla problema con el título de las páginas

### DIFF
--- a/pages/guias/colaborar.rst
+++ b/pages/guias/colaborar.rst
@@ -7,9 +7,6 @@
 .. type: text
 .. template: pagina.tmpl
 
-Colaborar
----------
-
 ¡Pull requests son bienvenidos! Recién estamos empezando,
 así que hay mucho por hacer.
 

--- a/pages/reglas.rst
+++ b/pages/reglas.rst
@@ -9,4 +9,4 @@
 
 Esta página debe contener las relgas de la comunidad.
 Como publicar avisos de trabajo, dónde hacer preguntas, etc
-(enlazar a nuestro `código de conducta </coc>`_ o mezclar ambas secciones).
+(enlazar a nuestro :doc:`código de conducta <coc>` o mezclar ambas secciones).

--- a/themes/custom/templates/pagina.tmpl
+++ b/themes/custom/templates/pagina.tmpl
@@ -3,6 +3,10 @@
 <%inherit file="pagina-base.tmpl"/>
 
 <%block name="contenido">
-  ## Insertar el contido de nuestros archivos
+  <h1>
+    <a href="${post.permalink()}">${post.title()|h}</a>
+  </h1>
+
+  ## Insertar el contenido de nuestros archivos
   ${post.text()}
 </%block>


### PR DESCRIPTION
Había un pequeño problema con los encabezados tipo h1 en las páginas. Faltaba editar el template como el de nikola https://github.com/getnikola/nikola/blob/master/nikola/data/themes/base/templates/post_header.tmpl#L7