### PR TITLE
Cambio dominio a Pythonecuador.org en Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ Código fuente del sitio de Python Ecuador
 
 # Colaborar
 
-Puedes ver nuestra guía en <https://pythonecuador.github.io/guias/colaborar/>.
+Puedes ver nuestra guía en <https://pythonecuador.org/guias/colaborar/>.


### PR DESCRIPTION
Se cambia dominio _anterior_  "https://pythonecuador.github.io/guias/colaborar/" por 
_nuevo_ "https://pythonecuador.org/guias/colaborar/" en archivo README.md