### PR TITLE
Arreglar y centrar el contenido del footer.

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -953,7 +953,7 @@ LICENSE = "GNU v3.0"
 # A small copyright notice for the page footer (in HTML).
 # (translatable)
 CONTENT_FOOTER = '''
-<div class="container">
+<div class="content">
     <p id="followus">
         <strong>Síguenos y forma parte de nuestra comunidad</strong>
     </p>


### PR DESCRIPTION
Se modifica la clase del _div_ del CONTENT_FOOTER en el archivo conf.py.
De `class="container"` pasa a `class="content"`, para corregir y centrar el footer y normalizar con el contenido.

![correccion_footer_pythonecuador](https://user-images.githubusercontent.com/11642622/45731810-fe459500-bb9e-11e8-8abc-6ebdc9d492da.png)
