### PR TITLE
Agregar para ignorar directorios de virtualenv y .vscode en gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,17 @@ __pycache__
 .doit.db.*
 cache/
 output/
+
+#pyenv
+.python-version
+
+#dotenv
+.env
+
+#virtualenv
+.venv
+venv/
+ENV/
+
+#IDES
+.vscode


### PR DESCRIPTION
Se agrega directorios de _virtualenv_ y _.vscode_ en el archivo `.gitignore`.
close #17 