### PR TITLE
Centrar contenido de página

### DIFF
--- a/themes/custom/templates/pagina-base.tmpl
+++ b/themes/custom/templates/pagina-base.tmpl
@@ -12,7 +12,7 @@
 
 <%block name="content">
   ## Insertar el contido de nuestros archivos
-  <div class="content padding-top margin-bottom">  
+  <div class="content padding-top margin-bottom">
     <div class="row">
       <div class="col-sm-8 col-sm-offset-2">
         <%block name="contenido">

--- a/themes/custom/templates/pagina-base.tmpl
+++ b/themes/custom/templates/pagina-base.tmpl
@@ -12,7 +12,7 @@
 
 <%block name="content">
   ## Insertar el contido de nuestros archivos
-  <div class="container padding-top margin-bottom">
+  <div class="content padding-top margin-bottom">  
     <div class="row">
       <div class="col-sm-8 col-sm-offset-2">
         <%block name="contenido">


### PR DESCRIPTION
En el archivo `themes/custom/templates/pagina-base.tmpl`en el  ```<%block name="content">``` se cambia la clase del _div_ principal de `class="container"` a `class="content"`, esto centra el contenido de la página. close #68 

![centrar_contenido](https://user-images.githubusercontent.com/11642622/46371256-7d31d780-c64d-11e8-9f27-a01dba45fb5f.png)
