### PR TITLE
Agregar index a guías

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -145,6 +145,7 @@ NAVIGATION_LINKS = {
         ("/eventos/", "Eventos"),
         ("/reglas/", "Reglas"),
         ("/quiero-ayudar/", "Quiero ayudar"),
+        ("/guias/", "Guías"),
         ("/becas/", "Becas"),
         ("/sponsors/", "Sponsors"),
         ("/quienes-somos/", "¿Quiénes somos?"),

--- a/pages/guias/index.rst
+++ b/pages/guias/index.rst
@@ -1,0 +1,7 @@
+.. title: Guías
+.. slug: index
+.. template: pagina.tmpl
+
+Guías escritas por la comunidad para la comunidad.
+
+- `Colaborar en el desarrollo del sitio <link://filename/pages/guias/colaborar.rst>`__


### PR DESCRIPTION
No existe la directiva `toctree` en rst plano, ni tampoco encontré una extensión. Toca listar las páginas a mano por ahora