### PR TITLE
Bajar monto mínimo para ser sponsor recurrente

### DIFF
--- a/pages/sponsors/aplicar.rst
+++ b/pages/sponsors/aplicar.rst
@@ -24,7 +24,7 @@ Recurrentes
 ~~~~~~~~~~~
 
 Para ser un sponsor de largo plazo debes hacer al menos 3 contribuciones recurrentes.
-Cada contribución se realiza cada mes y el monto mínimo de cada contribución debe ser de $50.
+Cada contribución se realiza cada mes y el monto mínimo de cada contribución debe ser de $20.
 
 **¿Qué obtengo a cambio?**
 


### PR DESCRIPTION
Lo de las donaciones no ha dado los resultados esperados, bueno, si ha dado resultados (2 donaciones + licencias por parte de Jet Brains). Pero, el propósito era atraer empresas locales, vamos a experimentar bajando el monto mínimo :)