### PR TITLE
Plugin para leer variables de configuración

### DIFF
--- a/.rstcheck.cfg
+++ b/.rstcheck.cfg
@@ -1,2 +1,2 @@
 [rstcheck]
-ignore_directives=config
+ignore_roles=config

--- a/.rstcheck.cfg
+++ b/.rstcheck.cfg
@@ -1,0 +1,2 @@
+[rstcheck]
+ignore_directives=config

--- a/pages/nuestra-comunidad.rst
+++ b/pages/nuestra-comunidad.rst
@@ -54,7 +54,7 @@ con una pequeña descripción:
   ¡La estás visitando ahora mismo!
   Encuentra información sobre la comunidad.
 
-- `Email (ecuadorpython@gmail.com) <ecuadorpython@gmail.com>`__
+- Email (:config:`BLOG_EMAIL`)
 
   Para una conversación más formal,
   escríbenos a nuestro correo electrónico.

--- a/pages/sponsors/aplicar.rst
+++ b/pages/sponsors/aplicar.rst
@@ -208,4 +208,3 @@ Ten en cuenta que somos una **comunidad**, no un banco o una empresa.
 Revisa nuestro :doc:`faq sobre donaciones <faq>`,
 y si algo aún no te queda claro o deseas más información,
 escríbenos a :config:`BLOG_EMAIL`.
-escríbenos a ecuadorpython@gmail.com.

--- a/pages/sponsors/aplicar.rst
+++ b/pages/sponsors/aplicar.rst
@@ -207,4 +207,5 @@ Ten en cuenta que somos una **comunidad**, no un banco o una empresa.
 
 Revisa nuestro :doc:`faq sobre donaciones <faq>`,
 y si algo aún no te queda claro o deseas más información,
+escríbenos a :config:`BLOG_EMAIL`.
 escríbenos a ecuadorpython@gmail.com.

--- a/plugins/config_role/README.md
+++ b/plugins/config_role/README.md
@@ -1,0 +1,11 @@
+Add the `config` role, it reads a value from the `conf.py` file.
+
+Usage:
+
+```rst
+Send us an email to :config:`BLOG_EMAIL`
+```
+
+Here `BLOG_EMAIL` is the variable name from the `conf.py` file.
+Note that the text is rendered as an email link, not just as plain text.
+This is because the value is interpreted as reStructuredText.

--- a/plugins/config_role/config_role.plugin
+++ b/plugins/config_role/config_role.plugin
@@ -1,0 +1,13 @@
+[Core]
+Name = config_role
+Module = config_role
+
+[Nikola]
+Compiler = rest
+PluginCategory = CompilerExtension
+
+[Documentation]
+Author = Santos Gallegos
+Version = 0.1
+Website = http://plugins.getnikola.com/#config_role
+Description = Inserts values from config.py

--- a/plugins/config_role/config_role.plugin
+++ b/plugins/config_role/config_role.plugin
@@ -4,7 +4,7 @@ Module = config_role
 
 [Nikola]
 Compiler = rest
-PluginCategory = CompilerExtension
+PluginCategory = RestExtension
 
 [Documentation]
 Author = Santos Gallegos

--- a/plugins/config_role/config_role.py
+++ b/plugins/config_role/config_role.py
@@ -1,0 +1,23 @@
+from docutils import nodes
+from docutils import utils
+from docutils.parsers.rst import roles
+from nikola.plugin_categories import RestExtension
+
+
+class Plugin(RestExtension):
+
+    name = 'config_role'
+
+    def set_site(self, site):
+        config_role.site = site
+        roles.register_canonical_role('config', config_role)
+        return super().set_site(site)
+
+
+def config_role(
+        name, rawtext, text, lineno, inliner, options=None, content=None):
+    options = options or {}
+    content = content or []
+    #  print(config_role.site.GLOBAL_CONTEXT)
+    config = config_role.site.config.get(text, '')
+    return [nodes.inline(rawtext, config)], []

--- a/plugins/config_role/config_role.py
+++ b/plugins/config_role/config_role.py
@@ -1,5 +1,5 @@
 """
-Add the `config` role, it reads a value from the conf.py file.
+Add the ``config`` role, it reads a value from the `conf.py` file.
 
 Usage:
 

--- a/plugins/config_role/config_role.py
+++ b/plugins/config_role/config_role.py
@@ -1,3 +1,15 @@
+"""
+Add the `config` role, it reads a value from the conf.py file.
+
+Usage:
+
+   Send us an email to :config:`BLOG_EMAIL`
+
+Here `BLOG_EMAIL` is the variable name from the conf.py file.
+Note that the text is rendered as an email link, not just as plain text.
+This is because the value is interpreted as reStructuredText.
+"""
+
 from docutils.frontend import OptionParser
 from docutils.parsers.rst import Parser, roles
 from docutils.utils import new_document

--- a/plugins/config_role/config_role.py
+++ b/plugins/config_role/config_role.py
@@ -1,6 +1,6 @@
-from docutils import nodes
-from docutils import utils
-from docutils.parsers.rst import roles
+from docutils.frontend import OptionParser
+from docutils.parsers.rst import Parser, roles
+from docutils.utils import new_document
 from nikola.plugin_categories import RestExtension
 
 
@@ -9,15 +9,32 @@ class Plugin(RestExtension):
     name = 'config_role'
 
     def set_site(self, site):
-        config_role.site = site
-        roles.register_canonical_role('config', config_role)
+        roles.register_canonical_role('config', config_role(site))
         return super().set_site(site)
 
 
-def config_role(
-        name, rawtext, text, lineno, inliner, options=None, content=None):
-    options = options or {}
-    content = content or []
-    #  print(config_role.site.GLOBAL_CONTEXT)
-    config = config_role.site.config.get(text, '')
-    return [nodes.inline(rawtext, config)], []
+def config_role(site):
+    """
+    Inject a value from the ``conf.py`` file.
+
+    Before injecting the value, it is parsed by the rst parser,
+    that way we can have a link when reading an email from the config
+    for example.
+
+    This role needs access to the `site` object.
+    As we can't pass extra args to a role function we are using a closure.
+    """
+    def role(name, rawtext, text, lineno, inliner, options=None, content=None):
+        parser = Parser()
+        settings = OptionParser(components=(Parser,)).get_default_values()
+        document = new_document('Raw rst from config value', settings)
+
+        config_value = site.config.get(text, '')
+        parser.parse(config_value, document)
+
+        # The whole text is interpreted as a big paragraph
+        # causing a new line to be inserted at the end,
+        # so we only take the elements inside that paragraph.
+        paragraph, *_ = document.children
+        return paragraph.children, []
+    return role


### PR DESCRIPTION
Esto es más un experimento, un plugin para leer desde varables del archivo de configuración, de esta manera no duplicamos cosas (como el email de la comunidad).

No está terminado, quiero que la config leida sea también interpretada como rst en lugar de texto plano.
Y talvez enviar el plugin al repo de nikola.