### PR TITLE
Agregar coc

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,1 @@
+Lee nuestro código de conducta en <https://pythonecuador.org/coc/> .

--- a/conf.py
+++ b/conf.py
@@ -145,7 +145,7 @@ NAVIGATION_LINKS = {
     DEFAULT_LANG: (
         ("/nuestra-comunidad/", "Comunidad"),
         ("/eventos/", "Eventos"),
-        ("/reglas/", "Reglas"),
+        ("/coc/", "Código de Conducta"),
         ("/quiero-ayudar/", "Quiero ayudar"),
         ("/guias/", "Guías"),
         ("/becas/", "Becas"),

--- a/pages/coc.rst
+++ b/pages/coc.rst
@@ -5,8 +5,66 @@
 .. link: 
 .. description: 
 .. type: text
-.. template: ayuda.tmpl
+.. template: pagina.tmpl
 
-Esta página debe tener nuestro código de conducta.
-Existen muchas ideas en https://github.com/PythonEcuador/PythonEcuador.github.io/issues/1
-sólo necesitarías sacar un par de ideas de ahí o proponer una tuya.
+Nuestro compromiso
+------------------
+
+En el interés de fomentar una comunidad abierta y acogedora,
+nosotros como contribuyentes y administradores nos comprometemos a hacer de la participación en nuestro proyecto
+y nuestra comunidad una experiencia libre de acoso para todos,
+independientemente de la edad, dimensión corporal, discapacidad, etnia, identidad y expresión de género,
+nivel de experiencia, nacionalidad, apariencia física, raza, religión, identidad u orientación sexual.
+
+Nuestros estándares
+-------------------
+
+Ejemplos de comportamiento que contribuyen a crear un ambiente positivo:
+
+* Uso de lenguaje amable e inclusivo
+* Respeto a diferentes puntos de vista y experiencias
+* Aceptación de críticas constructivas
+* Enfocarse en lo que es mejor para la comunidad
+* Mostrar empatía a otros miembros de la comunidad
+
+Ejemplos de comportamiento inaceptable por participantes:
+
+* Uso de lenguaje o imágenes sexuales y atención sexual no deseada
+* Comentarios insultantes o despectivos (trolling) y ataques personales o políticos
+* Acoso público o privado
+* Publicación de información privada de terceros sin su consentimiento, como direcciones físicas o electrónicas
+* Otros tipos de conducta que pudieran considerarse inapropiadas en un entorno profesional.
+
+Nuestras responsabilidades
+--------------------------
+
+Los administradores del proyecto son responsables de clarificar los estándares de comportamiento aceptable
+y se espera que tomen medidas correctivas y apropiadas en respuesta a situaciones de conducta inaceptable.
+
+Los administradores del proyecto tienen el derecho y la responsabilidad de eliminar,
+editar o rechazar comentarios, commits, código, ediciones de documentación, issues, y otras contribuciones que no estén alineadas con este Código de Conducta,
+o de prohibir temporal o permanentemente a cualquier colaborador cuyo comportamiento sea inapropiado, amenazante, ofensivo o perjudicial.
+
+Alcance
+-------
+
+Este código de conducta aplica tanto a espacios del proyecto como a espacios públicos donde un individuo esté en representación del proyecto o comunidad.
+Ejemplos de esto incluye el uso de la cuenta oficial de correo electrónico, publicaciones a través de las redes sociales oficiales,
+o presentaciones con personas designadas en eventos online u offline.
+La representación del proyecto puede ser clarificada explicitamente por los administradores del proyecto.
+
+Aplicación
+----------
+
+Ejemplos de abuso, acoso u otro tipo de comportamiento inaceptable puede ser reportado al equipo del proyecto en ecuadorpython@gmail.com.
+Todas las quejas serán revisadas e investigadas, generando un resultado apropiado a las circunstancias.
+El equipo del proyecto está obligado a mantener confidencialidad de la persona que reportó el incidente.
+Detalles específicos acerca de las políticas de aplicación pueden ser publicadas por separado.
+
+Administradores que no sigan o que no hagan cumplir este Código de Conducta pueden ser eliminados de forma temporal o permanente del equipo administrador.
+
+Atribución
+----------
+
+Este Código de Conducta es una adaptación del Contributor Covenant, versión 1.4,
+disponible en https://www.contributor-covenant.org/es/version/1/4/code-of-conduct.html


### PR DESCRIPTION
Copiado de https://www.contributor-covenant.org/es/version/1/4/code-of-conduct

Closes #1

Presonamente creo que es más apropiado http://citizencodeofconduct.org/, pero no existe una traducción al español, pero con esta estamos bien para empezar.

Si creen que falta algo por agregar, envíanos un pull request, crea un issue o comentalo en las redes de la comunidad.