### PR TITLE
Agregar template para posts

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -1237,6 +1237,9 @@ MARKDOWN_EXTENSIONS = ['markdown.extensions.fenced_code', 'markdown.extensions.c
 # before </head>
 # (translatable)
 EXTRA_HEAD_DATA = """
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
+<link rel="stylesheet" href="/assets/css/custom.css" type="text/css" media="all" />
+
 <!-- Global site tag (gtag.js) - Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=UA-128414584-1"></script>
 <script>

--- a/themes/custom/templates/includes/encabezado.tmpl
+++ b/themes/custom/templates/includes/encabezado.tmpl
@@ -1,7 +1,0 @@
-## -*- coding: utf-8 -*-
-
-## Font awesome: usado para tener íconos grandiosos en nuestro sitio
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
-
-## Nuestro css
-<link rel="stylesheet" href="/assets/css/custom.css" type="text/css" media="all" />

--- a/themes/custom/templates/index.tmpl
+++ b/themes/custom/templates/index.tmpl
@@ -2,7 +2,8 @@
 ## Nuesta página principal
 <%inherit file="pagina-base.tmpl"/>
 
-<%block name="encabezado_extra">
+<%block name="extra_head">
+  ${parent.extra_head()}
   <link rel="stylesheet" href="/assets/css/index.css" type="text/css" media="all" />
 </%block>
 

--- a/themes/custom/templates/pagina-base.tmpl
+++ b/themes/custom/templates/pagina-base.tmpl
@@ -2,14 +2,6 @@
 ## Template usado para nuestras paginas
 <%inherit file="base.tmpl"/>
 
-<%block name="extra_head">
-  ${parent.extra_head()}
-  <%include file="includes/encabezado.tmpl"/>
-  <%block name="encabezado_extra">
-    ## Bloque para agregar más etiquetas
-  </%block>
-</%block>
-
 <%block name="content">
   ## Insertar el contido de nuestros archivos
   <div class="content padding-top margin-bottom">

--- a/themes/custom/templates/post.tmpl
+++ b/themes/custom/templates/post.tmpl
@@ -1,0 +1,60 @@
+## -*- coding: utf-8 -*-
+
+## Copiado y adaptado de https://github.com/getnikola/nikola-themes/blob/master/v8/bootstrap3/templates/post.tmpl
+<%namespace name="helper" file="post_helper.tmpl"/>
+<%namespace name="pheader" file="post_header.tmpl"/>
+<%namespace name="comments" file="comments_helper.tmpl"/>
+<%namespace name="math" file="math_helper.tmpl"/>
+<%inherit file="pagina-base.tmpl"/>
+
+<%block name="extra_head">
+    ${parent.extra_head()}
+    % if post.meta('keywords'):
+    <meta name="keywords" content="${post.meta('keywords')|h}">
+    % endif
+    <meta name="author" content="${post.author()|h}">
+    %if post.prev_post:
+        <link rel="prev" href="${post.prev_post.permalink()}" title="${post.prev_post.title()|h}" type="text/html">
+    %endif
+    %if post.next_post:
+        <link rel="next" href="${post.next_post.permalink()}" title="${post.next_post.title()|h}" type="text/html">
+    %endif
+    % if post.is_draft:
+        <meta name="robots" content="noindex">
+    % endif
+    ${helper.open_graph_metadata(post)}
+    ${helper.twitter_card_information(post)}
+    ${helper.meta_translations(post)}
+    ${math.math_styles_ifpost(post)}
+</%block>
+
+<%block name="contenido">
+<article class="post-${post.meta('type')} h-entry hentry postpage" itemscope="itemscope" itemtype="http://schema.org/Article">
+    ${pheader.html_post_header()}
+    <div class="e-content entry-content" itemprop="articleBody text">
+    ${post.text()}
+    </div>
+    <aside class="postpromonav">
+    <nav>
+    ${helper.html_tags(post)}
+    ${helper.html_pager(post)}
+    </nav>
+    </aside>
+    % if not post.meta('nocomments') and site_has_comments:
+        <section class="comments hidden-print">
+        <h2>${messages("Comments")}</h2>
+        ${comments.comment_form(post.permalink(absolute=True), post.title(), post._base_path)}
+        </section>
+    % endif
+    ${math.math_scripts_ifpost(post)}
+</article>
+${comments.comment_link_script()}
+</%block>
+
+<%block name="sourcelink">
+% if show_sourcelink:
+    <li>
+    <a href="${post.source_link()}" id="sourcelink">${messages("Source")}</a>
+    </li>
+% endif
+</%block>


### PR DESCRIPTION
El template fue adaptado del tema original https://github.com/getnikola/nikola-themes/blob/master/v8/bootstrap3/templates/post.tmpl

El encabezado común no era tan común, y algunas páginas no mostraban el footer correctamente. Moviendo el encabezado a conf.py arregla todos estos problemas.

Esto es necesario para #161 