### PR TITLE
Agregado página del zen de python.

### DIFF
--- a/pages/quienes-somos.rst
+++ b/pages/quienes-somos.rst
@@ -30,3 +30,9 @@ Si aún no se existe una comunidad activa en tu ciudad,
 Cualquier persona con ganas de **aprender y compartir** con los demás.
 **No importa si jamás has escrito una línea de código**, todos estuvimos en tu lugar alguna vez y,
 por eso, estamos dispuestos a ayudarte si es que tu quieres aprender.
+
+¿Cuales son nuestros principios?
+--------------------------------
+
+Tenemos una **colección de principios** que influyen en el diseño del **Python**,
+y en nuestras vidas. Revisa: El `Zen de Python <link://filename/pages/zen.rst>`__.

--- a/pages/zen.rst
+++ b/pages/zen.rst
@@ -1,0 +1,36 @@
+.. title: Zen de Python
+.. slug: zen
+.. type: text
+.. template: pagina.tmpl
+
+Nuestra guía de principios, por Tim Peters:
+
+.. code:: python
+
+    import this
+
+1. Bello es mejor que feo.
+2. Explícito es mejor que implícito.
+3. Simple es mejor que complejo.
+4. Complejo es mejor que complicado.
+5. Plano es mejor que anidado.
+6. Disperso es mejor que denso.
+7. La legibilidad cuenta.
+8. Los casos especiales no son tan especiales como para quebrantar las reglas.
+9. Aunque lo práctico gana a la pureza.
+10. Los errores nunca deberían dejarse pasar silenciosamente.
+11. A menos que hayan sido silenciados explícitamente.
+12. Frente a la ambigüedad, rechaza la tentación de adivinar.
+13. Debería haber una - y preferiblemente sólo una - manera obvia de hacerlo.
+14. Aunque esa manera puede no ser obvia al principio a menos que usted sea holandés (Guido van Rossum).
+15. Ahora es mejor que nunca.
+16. Aunque nunca es a menudo mejor que ya mismo.
+17. Si la implementación es difícil de explicar, es una mala idea.
+18. Si la implementación es fácil de explicar, puede que sea una buena idea.
+19. Los 'namespaces' son una gran idea ¡Hagamos más de esas cosas!.
+
+|pep20|
+
+.. |pep20| raw:: html
+
+   <a href="https://www.python.org/dev/peps/pep-0020/" target="_blank">PEP 20</a>


### PR DESCRIPTION
Se modificó página "quienes-somos" para agregar enlace al zen traducido,
y se añadió la página "zen".