### PR TITLE
pequeño cambio-propuesta párrafo home

### DIFF
--- a/pages/quiero-ayudar.rst
+++ b/pages/quiero-ayudar.rst
@@ -26,6 +26,7 @@ De manera general las formas de apoyar a la comunidad son:
 
 Si posees conocimientos técnicos:
 
-* Contribuyendo en el desarrollo de nuestros proyectos alojados en `GitHub <https://github.com/PythonEcuador>`__, puedes comenzar con esta `guía <link://filename/pages/guias/colaborar.rst>`__.
+* Contribuyendo en el desarrollo de nuestros proyectos alojados en `GitHub <https://github.com/PythonEcuador>`__,
+  puedes comenzar con esta `guía <link://filename/pages/guias/colaborar.rst>`__.
 * Proponiendo y dictando charlas/talleres para fomentar el conocimiento de Python en la comunidad
 * Creando material de difusión como: afiches, banners, logos, etc.

--- a/pages/quiero-ayudar.rst
+++ b/pages/quiero-ayudar.rst
@@ -26,6 +26,6 @@ De manera general las formas de apoyar a la comunidad son:
 
 Si posees conocimientos técnicos:
 
-* Contribuyendo en el desarrollo de nuestros proyectos alojados en `GitHub <https://github.com/PythonEcuador>`__
+* Contribuyendo en el desarrollo de nuestros proyectos alojados en `GitHub <https://github.com/PythonEcuador>`__, puedes comenzar con esta `guía <link://filename/pages/guias/colaborar.rst>`__.
 * Proponiendo y dictando charlas/talleres para fomentar el conocimiento de Python en la comunidad
 * Creando material de difusión como: afiches, banners, logos, etc.

--- a/themes/custom/assets/css/index.css
+++ b/themes/custom/assets/css/index.css
@@ -81,3 +81,16 @@ footer a:hover {
   color: #fff;
   text-decoration: underline;
 }
+
+.yellow-highlight {
+  text-shadow: none;
+  font-weight: bold;
+  padding: 5px;
+  color: var(--blue);
+  background-color: var(--yellow);
+}
+
+.yellow-highlight:hover {
+  text-decoration: none;
+  color: #fff;
+}

--- a/themes/custom/assets/css/index.css
+++ b/themes/custom/assets/css/index.css
@@ -85,7 +85,7 @@ footer a:hover {
 .yellow-highlight {
   text-shadow: none;
   font-weight: bold;
-  padding: 5px;
+  padding: 4px;
   color: var(--blue);
   background-color: var(--yellow);
 }

--- a/themes/custom/templates/index.tmpl
+++ b/themes/custom/templates/index.tmpl
@@ -25,7 +25,7 @@
           </a>
         </p>
         <p class="small">
-          Mira lo que logramos este <a class="white-link" href="/resumen-2019/">2019</a>.
+          Mira lo que logramos este <a class="yellow-highlight" href="/resumen-2019/">2019</a>.
         </p>
       </div>
     </div>


### PR DESCRIPTION
Me parece que el resumen del 2019 de la comunidad de Python Ecuador esta muy bien hecho y resalta todo el trabajo realizado por la comunidad, pero cuando uno entra a la página no distingue con facilidad el resumen, por tal motivo propongo resaltar el link del resumen para que llame la atención a los visitantes de la página. También agregue un link desde la página quiero-ayudar hacia la guía de colaboración en el sitio de GitHub, para quién desee comenzar a colaborar con código pueda encontrar la guía más rápido.