### PR TITLE
Actualizar enlaces rotos

### DIFF
--- a/pages/coc.rst
+++ b/pages/coc.rst
@@ -67,4 +67,4 @@ Atribución
 ----------
 
 Este Código de Conducta es una adaptación del Contributor Covenant, versión 1.4,
-disponible en https://www.contributor-covenant.org/es/version/1/4/code-of-conduct.html
+disponible en https://www.contributor-covenant.org/es/version/1/4/code-of-conduct/

--- a/pages/eventos/index.rst
+++ b/pages/eventos/index.rst
@@ -21,7 +21,7 @@ Sesiones
 - **Lunes de Newbies**: Un espacio donde aprenderás a crear tu primer Pull Request, como funciona Git, un espacio divertido si eres un novato.
 - **Linux/Automatización/Docker**: Aprenderás lo básico de Linux, automatizar sus procesos, crear espacios para desarrollo mediante Docker
 - **Ejercicios de Programación**: Ejercicios para mejorar y practicar tu lógica en plataformas en linea como 
-  `HackerEarth <https://www.hackerearth.com/practice/codemonk>`__ y analizamos la complejidad computacional de las respuestas.
+  `HackerEarth <https://www.hackerearth.com/practice/codemonk/>`__ y analizamos la complejidad computacional de las respuestas.
 - **Bots**: Mejora y practica tus habilidades en Python mediante el uso y la creación de Bots.
 - **V/Vi/Vim/Viernes**: Aprende Vim o NeoVim, practica y si te animas puedes hasta crear tus propios plugins.
 - **¡Hasta que los Teclados Aguanten!**: Aprende a contribuir a un proyecto de Software Libre o propón tus proyectos favoritos.

--- a/pages/guias/psf.rst
+++ b/pages/guias/psf.rst
@@ -42,7 +42,7 @@ Abierto el email nos dirigimos a la bandeja de entrada y verificamos el email de
 
    	   You're receiving this e-mail because user xxxxxx at python.org has given yours as an e-mail address to connect  their account.
 
-   	   To confirm this is correct, go to http://www.python.org/accounts/confirm-email/your-email
+   	   To confirm this is correct, go to https://www.python.org/accounts/confirm-email/your-email/
  
    	   Thank you from python.org!.
 ..

--- a/pages/nuestra-comunidad.rst
+++ b/pages/nuestra-comunidad.rst
@@ -43,10 +43,6 @@ con una pequeña descripción:
   Nuestra principal plataforma para la organización de eventos.
   Recibe notificaciones de los eventos más cercanos a tu ubicación.
 
-- `Canal de Telegram (@pythonecuadoreventos) <https://t.me/pythonecuadoreventos>`__
-
-  Recibe notificaciones de nuestros últimos eventos.
-
 - `Facebook (@pyecuador) <https://www.facebook.com/pyecuador/>`__
 
   Contenido relacionado a la comunidad y Python.
@@ -69,7 +65,7 @@ con una pequeña descripción:
 
   ¿Te perdiste un meetup? Puede que esté en nuestro canal de YouTube.
 
-- `Web <https://pythonecuador.org>`__
+- `Web <https://python.ec>`__
 
   ¡La estás visitando ahora mismo!
   Encuentra información sobre la comunidad.
@@ -93,7 +89,7 @@ Otras comunidades
 
 - `PyladiesEc - Twitter <https://twitter.com/PyladiesEc>`__
 
-- `PyladiesEc - Facebook <https://www.facebook.com/pyladiesecq/>`__
+- `PyladiesEc - Facebook <https://www.facebook.com/pyladiesec/>`__
 
 
 Comunidades amigas

--- a/pages/sponsors/index.rst
+++ b/pages/sponsors/index.rst
@@ -28,7 +28,7 @@ Sponsors no recurrentes
 
 Lista de sponsors que han hecho una donación:
 
-- `EÓN CORP <http://eonidi.com>`__ (01/09/2018, $20)
+- `EÓN CORP <https://eonidi.com/>`__ (01/09/2018, $20)
 - `Leonardo Gómez <https://twitter.com/gomezgleonardob>`__ (01/09/2018, $20)
 
 Sponsors pasados

--- a/themes/custom/templates/resumen-2019.tmpl
+++ b/themes/custom/templates/resumen-2019.tmpl
@@ -279,7 +279,7 @@
             <a href="https://t.me/pythonecuador/">Telegram: +390 miembros</a>
           </li>
           <li>
-            <a href="https://twitter/pyecuador">Twitter: +360 seguidores</a>
+            <a href="https://twitter.com/pyecuador">Twitter: +360 seguidores</a>
           </li>
         </ul>
       </div>
@@ -293,7 +293,7 @@
         </p>
         <ul class="timeline">
           <li>
-            <a href="https://www.facebook.com/pyladiesecq/">PyLadies</a>
+            <a href="https://www.facebook.com/pyladiesec/">PyLadies</a>
           </li>
           <li>
             <a href="https://twitter.com/funpython_ec">FunPython</a>


### PR DESCRIPTION
Aún no podemos usar este comando

```
nikola check -rl
```

porque hay un bug, pero esperamos que en el siguiente release ya salga el fix :D


```python
LINK_CHECK_WHITELIST = [
    # Enlaces locales
    r'^http://127\.0\.0\.1',

    # Por alguna razón telegram está bloqueando el request
    r'^https://t\.me/pythonecuador/?$',

    # El evento fue eliminado
    r'^https://www\.thoughtworks\.com/xconf-america-latina-2019$',
    r'^https://forms\.gle/damjijn6HhX9FYUq7$',
]

```