### PR TITLE
add get_last_commit()

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -997,7 +997,8 @@ CONTENT_FOOTER = '''
 def get_last_commit():
     encoding = 'utf-8'
     command = subprocess.run(["git", "rev-parse", "HEAD"], capture_output=True)
-    return command.stdout.decode(encoding)
+    last_hash = command.stdout.decode(encoding)
+    return last_hash[0:8]
 
 CONTENT_FOOTER_FORMATS = {
     DEFAULT_LANG: (


### PR DESCRIPTION
Añadí una función para obtener el commit actual con el que fue construido el sitio.
Actualmente se ve así:
![image](https://user-images.githubusercontent.com/20387293/137241097-7ef1d394-63e4-49d0-84ec-2af2e265b60a.png)


Close #290