### PR TITLE
Fix tests

### DIFF
--- a/.rstcheck.cfg
+++ b/.rstcheck.cfg
@@ -1,0 +1,3 @@
+[rstcheck]
+ignore_roles=
+  ref


### PR DESCRIPTION
rstcheck necesita que los roles que no son incluidos por defecto sean declarados.