### PR TITLE
Consejos útiles instalación windows

### DIFF
--- a/pages/guias/colaborar.rst
+++ b/pages/guias/colaborar.rst
@@ -31,6 +31,9 @@ Este proyecto usa Python 3, puedes descargarlo desde https://www.python.org/down
 Para verificar que tienes Python 3 en tu sistema ejecuta el siguiente comando en una terminal
 (ventana de comandos):
 
+Si la versión descargada de python es para Windows, es conveniente marcar la opción PATH,
+con la finalidad de que las variables de entorno se reconozcan en cualquier entorno.
+
 .. code:: console
 
    $ python --version

--- a/pages/guias/colaborar.rst
+++ b/pages/guias/colaborar.rst
@@ -33,7 +33,7 @@ Para verificar que tienes Python 3 en tu sistema ejecuta el siguiente comando en
 
 Si la versión descargada de python es para Windows, es conveniente marcar la opción PATH,
 con la finalidad de que las variables de entorno se reconozcan en cualquier terminal abierto ya que
-facilita la ejecución a futuro del comando pip install y no lo restringe al directorio de instalación.
+facilita la ejecución a futuro del comando ``pip install`` y no lo restringe al directorio de instalación.
 
 .. code:: console
 

--- a/pages/guias/colaborar.rst
+++ b/pages/guias/colaborar.rst
@@ -32,7 +32,8 @@ Para verificar que tienes Python 3 en tu sistema ejecuta el siguiente comando en
 (ventana de comandos):
 
 Si la versión descargada de python es para Windows, es conveniente marcar la opción PATH,
-con la finalidad de que las variables de entorno se reconozcan en cualquier entorno.
+con la finalidad de que las variables de entorno se reconozcan en cualquier terminal abierto ya que
+facilita la ejecución a futuro del comando pip install y no lo restringe al directorio de instalación.
 
 .. code:: console
 


### PR DESCRIPTION
El momento de instalar python para windows, se necesita tener las variables de entorno en cualquier consola que se ejecute y al no hacer este paso se dificulta ejecutar pip install desde cualquier lugar y se restringe únicamente al directorio donde fue instalado python.