### PR TITLE
chance filename by archive in links

### DIFF
--- a/pages/becas.rst
+++ b/pages/becas.rst
@@ -6,7 +6,7 @@
 
 Queremos que todas las personas puedan participar en nuestros eventos.
 La distancia ni tu situación económica debe ser un obstáculo para aprender.
-Esta sección es posible gracias a `nuestros sponsors <link://filename/pages/sponsors/index.rst>`__.
+Esta sección es posible gracias a `nuestros sponsors <link://archive/sponsors>`__.
 
 .. note::
 
@@ -140,7 +140,7 @@ Restricciones y condiciones
 - La información de contacto es de una persona real.
 - La comunidad no se responsabiliza por cualquier inconveniente
   presentado, nuestra única responsabilidad es hacerte llegar el dinero.
-- Nos reservamos el derecho de rechazar tu aplicación si has violado nuestro `código de conducta <link://filename/pages/coc.rst>`__.
+- Nos reservamos el derecho de rechazar tu aplicación si has violado nuestro `código de conducta <link://archive/coc>`__.
 
 FAQ
 ---
@@ -166,7 +166,7 @@ eres más que bienvenido a aplicar.
 ¿Cómo puedo aumentar mis posibilidades de aplicar?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- Siendo miembro activo en la `comunidad <link://filename/pages/nuestra-comunidad.rst>`__.
+- Siendo miembro activo en la `comunidad <link://archive/nuestra-comunidad>`__.
 - Ofreciéndote a dar una charla en el meetup que vas a asistir (si es posible).
 - Ofreciéndote a ayudar con la organización del evento.
 - Ofreciéndote a seguir difundiendo la comunidad.

--- a/pages/eventos/index.rst
+++ b/pages/eventos/index.rst
@@ -15,7 +15,7 @@ Estos son los tipos de eventos que se realizan en la comunidad de Python Ecuador
 Calendario de Eventos
 ---------------------
 
-Lista y horarios en nuestro `calendario de eventos <link://filename/pages/calendar.rst>`__.
+Lista y horarios en nuestro `calendario de eventos <link://archive/calendar>`__.
 
 Sesiones
 ########
@@ -37,14 +37,14 @@ en las reuniones de `charlas y talleres (meetups) <https://www.meetup.com/python
 PyPizza
 #######
 
-Evento informal en el que te ayudamos a colaborar a un proyecto de Software Libre y disfrutar de una pizza en `PyPizza <link://filename/pages/eventos/pypizza.rst>`__.
+Evento informal en el que te ayudamos a colaborar a un proyecto de Software Libre y disfrutar de una pizza en `PyPizza <link://archive/eventos/pypizza/>`__.
 
 Eventos en Vivo
 ###############
 
-Charlas y conferencias impartidas por la comunidad síguenos en `eventos en vivo <link://filename/pages/live.rst>`__.
+Charlas y conferencias impartidas por la comunidad síguenos en `eventos en vivo <link://archive/live>`__.
 
 Hacktoberfest
 #############
 
-Llega Octubre y es hora de participar en el `Hacktoberfest <link://filename/pages/hacktoberfest.rst>`__, donde durante todo el mes podrás contribuir a proyectos Open Source. ¿Nunca los haz hecho? ¿Quieres participar? Anímate! Esta es tu oportunidad para ser parte de un evento a escala mundial. ¡Happy Hacking!
+Llega Octubre y es hora de participar en el `Hacktoberfest <link://archive/hacktoberfest>`__, donde durante todo el mes podrás contribuir a proyectos Open Source. ¿Nunca los haz hecho? ¿Quieres participar? Anímate! Esta es tu oportunidad para ser parte de un evento a escala mundial. ¡Happy Hacking!

--- a/pages/guias/index.rst
+++ b/pages/guias/index.rst
@@ -7,17 +7,17 @@ Guías escritas por la comunidad para la comunidad.
 Comunidad
 #########
 
-- `EL Zen de Python <link://filename/pages/zen.rst>`__.
-- `Registrarte como miembro de la PSF <link://filename/pages/guias/psf.rst>`__
+- `EL Zen de Python <link://archive/zen>`__.
+- `Registrarte como miembro de la PSF <link://archive/guias/psf>`__
 
 Desarrollo del sitio
 ####################
 
-- `Colaborar en el desarrollo del sitio <link://filename/pages/guias/colaborar.rst>`__
-- `Mini tutorial de reStructuredText <link://filename/pages/guias/rst.rst>`__
-- `Deploy del sitio <link://filename/pages/guias/deploy.rst>`__
+- `Colaborar en el desarrollo del sitio <link://archive/guias/colaborar>`__
+- `Mini tutorial de reStructuredText <link://archive/guias/rst>`__
+- `Deploy del sitio <link://archive/guias/deploy>`__
 
 Administración
 --------------
 
-- `Licencias de JetBrains <link://filename/pages/guias/licencias.rst>`__
+- `Licencias de JetBrains <link://archive/guias/licencias>`__

--- a/pages/nuestra-comunidad.rst
+++ b/pages/nuestra-comunidad.rst
@@ -10,7 +10,7 @@ con la filosofía común de que el **conocimiento debe ser libre**.
 
 **No lucramos con ningún evento**, y esperamos llegar a todos aquellos que desean aprender.
 
-`Leer más <link://filename/pages/quienes-somos.rst>`__.
+`Leer más <link://archive/quienes-somos>`__.
 
 .. contents:: Contenidos
    :depth: 2
@@ -18,7 +18,7 @@ con la filosofía común de que el **conocimiento debe ser libre**.
 Eventos
 -------
 
-Puedes encontrar una lista de los eventos que se organizan en la comunidad `aquí <link://filename/pages/eventos/index.rst>`__.
+Puedes encontrar una lista de los eventos que se organizan en la comunidad `aquí <link://archive/eventos>`__.
 
 Redes Sociales
 --------------
@@ -28,7 +28,7 @@ cada una es administrada por miembros de la comunidad en su tiempo libre.
 
 .. warning::
 
-   En cada red/comunidad debes seguir nuestro `Código de conducta <link://filename/pages/coc.rst>`__.
+   En cada red/comunidad debes seguir nuestro `Código de conducta <link://archive/coc>`__.
    Evita ser expulsado, siempre sé amable y respetuoso con los demás.
 
 Aquí podrás encontrar una lista de nuestras redes/comunidades oficiales

--- a/pages/quiero-ayudar.rst
+++ b/pages/quiero-ayudar.rst
@@ -15,18 +15,18 @@ fomentar el uso y conocimiento del lenguaje Python en el país y el mundo.
 Personas con conocimientos técnicos y no técnicos pueden aportar desde sus diferentes habilidades.
 De manera general las formas de apoyar a la comunidad son:
 
-* Asistiendo y difundiendo los `eventos y actividades <link://filename/pages/eventos/index.rst>`__ de la comunidad
+* Asistiendo y difundiendo los `eventos y actividades <link://archive/eventos>`__ de la comunidad
 * Ayudando a nuevas personas a integrarse a la comunidad
-* Cuidando que se respete `nuestro código de conducta <link://filename/pages/coc.rst>`__
+* Cuidando que se respete `nuestro código de conducta <link://archive/coc>`__
 * Ayudando en la organización de eventos
 * Reportando errores o sugerencias en `los proyectos de la comunidad <https://github.com/PythonEcuador>`__
-* Participando en `nuestras redes <link://filename/pages/nuestra-comunidad.rst>`__
+* Participando en `nuestras redes <link://archive/nuestra-comunidad>`__
 * Impresión de material de difusión
-* `Haciendo una donación <https://opencollective.com/pythonecuador/>`__ o `convirtiéndote en sponsor <link://filename/pages/sponsors/aplicar.rst>`__
+* `Haciendo una donación <https://opencollective.com/pythonecuador/>`__ o `convirtiéndote en sponsor <link://archive/sponsors/aplicar>`__
 
 Si posees conocimientos técnicos:
 
 * Contribuyendo en el desarrollo de nuestros proyectos alojados en `GitHub <https://github.com/PythonEcuador>`__,
-  puedes comenzar con esta `guía <link://filename/pages/guias/colaborar.rst>`__.
+  puedes comenzar con esta `guía <link://archive/guias/colaborar>`__.
 * Proponiendo y dictando charlas/talleres para fomentar el conocimiento de Python en la comunidad
 * Creando material de difusión como: afiches, banners, logos, etc.

--- a/pages/sponsors/faq.rst
+++ b/pages/sponsors/faq.rst
@@ -46,7 +46,7 @@ háznoslo saber.
 
 No, la comunidad es dirigida por la comunidad,
 Python Ecuador siempre será una comunidad independiente.
-Un sponsor sólo recibe los beneficios detallados en la página `aplicar <link://filename/pages/sponsors/aplicar.rst>`__.
+Un sponsor sólo recibe los beneficios detallados en la página `aplicar <link://archive/sponsors/aplicar>`__.
 
 ¿Por qué no piden dinero a organizaciones como la PSF?
 ------------------------------------------------------
@@ -74,7 +74,7 @@ No tengo dinero ¿De qué otra forma puedo ayudar?
 
 ¡Gracias por el interés en ayudar!
 Siempre estamos buscando más personas que se sumen a la organización de eventos.
-Puedes revisar `esta sección <link://filename/pages/quiero-ayudar.rst>`__ para ver todas las formas de ayudar.
+Puedes revisar `esta sección <link://archive/quiero-ayudar>`__ para ver todas las formas de ayudar.
 
 ¿Más preguntas?
 ---------------

--- a/pages/sponsors/index.rst
+++ b/pages/sponsors/index.rst
@@ -8,9 +8,9 @@ pero gracias a la **generosa ayuda financiera de nuestros sponsors** la comunida
 
 *Realiza tu donación a través de Open Collective* https://opencollective.com/pythonecuador.
 
-*¿Te interesa ser un sponsor de nuestra comunidad?* `aplicar <link://filename/pages/sponsors/aplicar.rst>`__.
+*¿Te interesa ser un sponsor de nuestra comunidad?* `aplicar <link://archive/sponsors/aplicar>`__.
 
-*¿Dudas o preguntas sobre esta sección?* `faq <link://filename/pages/sponsors/faq.rst>`__.
+*¿Dudas o preguntas sobre esta sección?* `faq <link://archive/sponsors/faq>`__.
 
 .. contents:: Contenidos
    :depth: 1


### PR DESCRIPTION
Using archive instead of filename the links are generated correctly by magic links in windows.  it also works in linux.